### PR TITLE
Fix logic error on table sort function

### DIFF
--- a/StdLib/table.lua
+++ b/StdLib/table.lua
@@ -246,18 +246,20 @@ function table.deepcopy(object)
     return _copy(object)
 end
 
+--- Default table comparator sort function.
+-- @local
+-- @param x one comparator operand
+-- @param y the other comparator operand
+-- @return true if x logically comes before y in a list, false otherwise
 local sortfunc =
     function(x, y) --sorts tables with mixed index types.
         local tx = type(x)
         local ty = type(y)
         if tx == ty then
-            if type(x) == 'string' and type(y) == 'string' then
-                if string.lower(x) == string.lower(y) then
-                    return x < y
-                end
+            if type(x) == 'string' then
                 return string.lower(x) < string.lower(y)
             else
-                return x < y and true or false --similar type can be compared
+                return x < y
             end
         elseif tx == 'number' then
             return true --only x is a number and goes first

--- a/StdLib/table.lua
+++ b/StdLib/table.lua
@@ -259,7 +259,7 @@ local sortfunc =
             else
                 return x < y and true or false --similar type can be compared
             end
-        elseif tx == true then
+        elseif tx == 'number' then
             return true --only x is a number and goes first
         else
             return false --only y is a number and goes first


### PR DESCRIPTION
This is used probably elsewhere but the warp list is the main place this error manifests whereby strings are sorted by ascii code rather than lexicographically. This is not wrong per se, but I do not think it was the intended behavior and the scenario gameplay is a bit impacted by the current sort order. This PR resolves the issue.