### PR TITLE
Changed cutoff time for furnaces and burners

### DIFF
--- a/config/advanced_start.lua
+++ b/config/advanced_start.lua
@@ -79,8 +79,8 @@ return {
         ['electronic-circuit']=scale_amount_made(1000,0,6),
         ['iron-gear-wheel']=scale_amount_made(1000,0,6),
         -- Starting Items
-        ['burner-mining-drill']=cutoff_time(5*minutes,4,0),
-        ['stone-furnace']=cutoff_time(5*minutes,4,0),
+        ['burner-mining-drill']=cutoff_time(10*minutes,4,0),
+        ['stone-furnace']=cutoff_time(10*minutes,4,0),
         -- Armor
         ['light-armor']=cutoff_amount_made_unless(5,0,1,'heavy-armor',5),
         ['heavy-armor']=cutoff_amount_made(5,0,1),


### PR DESCRIPTION
Changed it to 10 mins as sometimes its really annoying when someone joins for 5 minutes doing nothing then leaves. Has happened a few times before and it just slows down progress massively