### PR TITLE
Added Custom Join Messages

### DIFF
--- a/config/join_messages.lua
+++ b/config/join_messages.lua
@@ -1,3 +1,6 @@
 return {
-    ['Cooldude2606'] = 'Lua lets you set metatables on numbers, did you know that? Cooldude2606 knows this.'
+    Cooldude2606 = 'Lua lets you set metatables on numbers, did you know that? Cooldude2606 knows this.',
+    samy115 = 'Tremble in fear as the banhammer is now here, its owner: samy115',
+    XenoCyber = '"Fire :fire: Fire :fire: Fire" oops wrong game, have no fear XenoCyber is here',
+    HunterOfGames = 'Unable to support HunterOfGames. You must construct additional miners.'
 }

--- a/config/join_messages.lua
+++ b/config/join_messages.lua
@@ -1,6 +1,6 @@
 return {
     Cooldude2606 = 'Lua lets you set metatables on numbers, did you know that? Cooldude2606 knows this.',
     samy115 = 'Tremble in fear as the banhammer is now here, its owner: samy115',
-    XenoCyber = '"Fire :fire: Fire :fire: Fire" oops wrong game, have no fear XenoCyber is here',
+    XenoCyber = '"Fire Fire Fire" oops wrong game, have no fear XenoCyber is here',
     HunterOfGames = 'Unable to support HunterOfGames. You must construct additional miners.'
 }

--- a/config/join_messages.lua
+++ b/config/join_messages.lua
@@ -1,0 +1,3 @@
+return {
+    ['Cooldude2606'] = 'Lua lets you set metatables on numbers, did you know that? Cooldude2606 knows this.'
+}

--- a/config/preset_player_colours.lua
+++ b/config/preset_player_colours.lua
@@ -16,7 +16,10 @@ return {
 		UUBlueFire={r=0,g=204,b=255},
 		CmonMate497={r=103,g=224,b=194},
 		s4sh={r=255,g=120,b=0},
-		ArPiiX={r=0,g=255,b=0}
+		ArPiiX={r=0,g=255,b=0},
+		NextIdea={r=255,g=255,b=255},
+		hamsterbryan={r=0,g=255,b=0},
+		XenoCyber={r=0,g=128,b=255}
 	},
 	disallow = { --- @setting disallow colours which will not given to players; the value does not matter it is only the key which is checked
 		black = {r = 0, g = 0, b = 0},

--- a/modules/addons/greetings.lua
+++ b/modules/addons/greetings.lua
@@ -1,14 +1,25 @@
 --greets players on join
 
 local Event = require 'utils.event' --- @dep utils.event
-local greet = 
-function(event) 
-    local message = {'greetings.greet',{'links.discord'}}
-    game.players[event.player_index].print(message)
+local Game = require 'utils.game' --- @dep utils.event
+local config = require 'config.join_messages' --- @dep config.join_messages
+local Global = require 'utils.global' --- @dep utils.global
+require 'utils.table'
 
+Global.register(config,function(tbl)
+    config = tbl
+end)
+
+local greet =
+function(event)
+    local player = Game.get_player_by_index(event.player_index)
+    local custom_message = config[player.name]
+    if custom_message then
+        game.print(custom_message,player.color)
+    else
+        player.print{'greetings.greet',{'links.discord'}}
+    end
 
 end
 
-
-
-Event.add(defines.events.on_player_joined_game ,greet)
+Event.add(defines.events.on_player_joined_game, greet)


### PR DESCRIPTION
When a player joins a custom join message will be printed in chat for everyone to see. This message is set in the script after they have told us what message they want. Currently open for donators and staff.