### PR TITLE
Fix async module to allow recursive "async" functions

### DIFF
--- a/expcore/async.lua
+++ b/expcore/async.lua
@@ -36,7 +36,7 @@ local Async = {}
 local internal_run =
 Token.register(function(params)
     local func = Token.get(params.token)
-    func(unpack(params.params))
+    return func(unpack(params.params))
 end)
 
 --- Register a new async function, must called when the file is loaded


### PR DESCRIPTION
Return `true` in async function to run again