### PR TITLE
Feature/loadquickbar

### DIFF
--- a/config/_file_loader.lua
+++ b/config/_file_loader.lua
@@ -27,6 +27,7 @@ return {
     'modules.commands.find',
     'modules.commands.bonus',
     'modules.commands.home',
+    'modules.commands.quickbar',
     -- QoL Addons
     'modules.addons.station-auto-name',
     'modules.addons.greetings',

--- a/config/expcore/roles.lua
+++ b/config/expcore/roles.lua
@@ -141,6 +141,7 @@ Roles.new_role('Sponsor','Spon')
     'command/home-get',
     'command/return',
     'fast-tree-decon',
+    'command/load-quickbar'
 }
 
 Roles.new_role('Supporter','Sup')

--- a/config/expcore/roles.lua
+++ b/config/expcore/roles.lua
@@ -141,7 +141,8 @@ Roles.new_role('Sponsor','Spon')
     'command/home-get',
     'command/return',
     'fast-tree-decon',
-    'command/load-quickbar'
+    'command/load-quickbar',
+    'command/save-quickbar'
 }
 
 Roles.new_role('Supporter','Sup')

--- a/config/preset_player_quickbar.lua
+++ b/config/preset_player_quickbar.lua
@@ -2,5 +2,5 @@
 -- @config Preset-Player-Quickbar
 
 return {
-	dangerarea={'transport-belt','fast-transport-belt'}
+	dangerarea={"transport-belt",[2]="fast-transport-belt","express-transport-belt",[11]="transport-belt",[23]="fast-transport-belt",[33]="express-transport-belt"}
 }

--- a/config/preset_player_quickbar.lua
+++ b/config/preset_player_quickbar.lua
@@ -2,7 +2,5 @@
 -- @config Preset-Player-Quickbar
 
 return {
-	players={ --- @setting players list of all players and their quickbar items
-		dangerarea={'transport-belt','fast-transport-belt'}
-    }
+	dangerarea={'transport-belt','fast-transport-belt'}
 }

--- a/config/preset_player_quickbar.lua
+++ b/config/preset_player_quickbar.lua
@@ -1,0 +1,8 @@
+--- Preset quickbar items that players can load
+-- @config Preset-Player-Quickbar
+
+return {
+	players={ --- @setting players list of all players and their quickbar items
+		dangerarea={'transport-belt','fast-transport-belt'}
+    }
+}

--- a/config/preset_player_quickbar.lua
+++ b/config/preset_player_quickbar.lua
@@ -2,5 +2,5 @@
 -- @config Preset-Player-Quickbar
 
 return {
-	dangerarea={"transport-belt",[2]="fast-transport-belt","express-transport-belt",[11]="transport-belt",[23]="fast-transport-belt",[33]="express-transport-belt"}
+	dangerarea = {"transport-belt", "underground-belt", "splitter", "pipe", "pipe-to-ground", "inserter", "fast-inserter", "long-handed-inserter", "stack-inserter", "roboport", "small-electric-pole", "medium-electric-pole", "big-electric-pole", "substation", nil, "rail", "rail-signal", "rail-chain-signal", "landfill", "cliff-explosives", "fast-transport-belt", "fast-underground-belt", "fast-splitter", "pipe", "pipe-to-ground", "fast-inserter", "long-handed-inserter", "stack-inserter", "stack-filter-inserter", "roboport", [81] = "red-wire", [82] = "green-wire", [83] = "arithmetic-combinator", [84] = "decider-combinator", [85] = "constant-combinator", [86] = "power-switch", [91] = "logistic-chest-active-provider", [92] = "logistic-chest-passive-provider", [93] = "logistic-chest-storage", [94] = "logistic-chest-buffer", [95] = "logistic-chest-requester", [96] = "roboport"}
 }

--- a/modules/commands/quickbar.lua
+++ b/modules/commands/quickbar.lua
@@ -35,7 +35,7 @@ Commands.new_command('save-quickbar','Saves your Quickbar preset items to file')
     for i=1, 100 do
         local slot = player.get_quick_bar_slot(i)
         if slot ~= nil then
-            table.insert(quickbar_names, i, slot.name)
+            quickbar_names[i] = slot.name
         end
     end
     game.write_file("quickbar_preset.txt", player.name .. " = " .. serpent.line(quickbar_names) .. "\n", true)

--- a/modules/commands/quickbar.lua
+++ b/modules/commands/quickbar.lua
@@ -1,0 +1,26 @@
+--[[-- Commands Module - Quickbar
+    - Adds a command that allows players to load Quickbar presets
+    @commands LoadQuickbar
+]]
+
+local Commands = require 'expcore.commands' --- @dep expcore.commands
+local Roles = require 'expcore.roles' --- @dep expcore.roles
+local Game = require 'utils.game' --- @dep utils.game
+local config = require 'config.preset_player_quickbar' --- @dep config.preset_player_quickbar
+require 'config.expcore.command_general_parse'
+
+
+--- Changes the amount of bonus you receive
+-- @command bonus
+-- @tparam number amount range 0-50 the percent increase for your bonus
+Commands.new_command('load-quickbar','Loads your preset Quickbar items')
+:register(function(player)
+    if config.players[player.name] then
+        local custom_quickbar = config.players[player.name]
+        for i, item_name in ipairs(custom_quickbar) do
+          player.set_quick_bar_slot(i, item_name)
+        end
+    else
+        Commands.print('Quickbar preset not found','red')
+    end
+end)

--- a/modules/commands/quickbar.lua
+++ b/modules/commands/quickbar.lua
@@ -1,13 +1,13 @@
 --[[-- Commands Module - Quickbar
     - Adds a command that allows players to load Quickbar presets
     @commands LoadQuickbar
+    @commands SaveQuickbar
 ]]
 
 local Commands = require 'expcore.commands' --- @dep expcore.commands
 local Roles = require 'expcore.roles' --- @dep expcore.roles
 local Game = require 'utils.game' --- @dep utils.game
 local config = require 'config.preset_player_quickbar' --- @dep config.preset_player_quickbar
-require 'config.expcore.command_general_parse'
 
 
 --- Loads your quickbar preset
@@ -16,10 +16,29 @@ Commands.new_command('load-quickbar','Loads your preset Quickbar items')
 :register(function(player)
     if config[player.name] then
         local custom_quickbar = config[player.name]
-        for i, item_name in ipairs(custom_quickbar) do
-          player.set_quick_bar_slot(i, item_name)
+        for i, item_name in pairs(custom_quickbar) do
+          if item_name ~= nil and item_name ~= '' then
+            player.set_quick_bar_slot(i, item_name)
+          end
         end
     else
         Commands.error('Quickbar preset not found')
     end
+end)
+
+--- Saves your quickbar preset to the script-output folder
+-- @command save-quickbar
+Commands.new_command('save-quickbar','Saves your Quickbar preset items to file')
+:register(function(player)
+    local quickbar_names = {}
+    for i=1, 100 do
+        local slot = player.get_quick_bar_slot(i)
+        if slot ~= nil then
+            table.insert(quickbar_names, slot.name)
+        else
+            table.insert(quickbar_names, "")
+        end
+    end
+    game.write_file("quickbar_preset.txt", game.table_to_json(quickbar_names), false)
+    Commands.print("Quickbar saved to local script-output folder")
 end)

--- a/modules/commands/quickbar.lua
+++ b/modules/commands/quickbar.lua
@@ -10,9 +10,8 @@ local config = require 'config.preset_player_quickbar' --- @dep config.preset_pl
 require 'config.expcore.command_general_parse'
 
 
---- Changes the amount of bonus you receive
--- @command bonus
--- @tparam number amount range 0-50 the percent increase for your bonus
+--- Loads your quickbar preset
+-- @command load-quickbar
 Commands.new_command('load-quickbar','Loads your preset Quickbar items')
 :register(function(player)
     if config.players[player.name] then

--- a/modules/commands/quickbar.lua
+++ b/modules/commands/quickbar.lua
@@ -14,12 +14,12 @@ require 'config.expcore.command_general_parse'
 -- @command load-quickbar
 Commands.new_command('load-quickbar','Loads your preset Quickbar items')
 :register(function(player)
-    if config.players[player.name] then
-        local custom_quickbar = config.players[player.name]
+    if config[player.name] then
+        local custom_quickbar = config[player.name]
         for i, item_name in ipairs(custom_quickbar) do
           player.set_quick_bar_slot(i, item_name)
         end
     else
-        Commands.print('Quickbar preset not found','red')
+        Commands.error('Quickbar preset not found')
     end
 end)

--- a/modules/commands/quickbar.lua
+++ b/modules/commands/quickbar.lua
@@ -13,12 +13,13 @@ local config = require 'config.preset_player_quickbar' --- @dep config.preset_pl
 --- Loads your quickbar preset
 -- @command load-quickbar
 Commands.new_command('load-quickbar','Loads your preset Quickbar items')
+:add_alias('load-toolbar')
 :register(function(player)
     if config[player.name] then
         local custom_quickbar = config[player.name]
         for i, item_name in pairs(custom_quickbar) do
           if item_name ~= nil and item_name ~= '' then
-            player.set_quick_bar_slot(i, item_name)
+              player.set_quick_bar_slot(i, item_name)
           end
         end
     else
@@ -29,16 +30,15 @@ end)
 --- Saves your quickbar preset to the script-output folder
 -- @command save-quickbar
 Commands.new_command('save-quickbar','Saves your Quickbar preset items to file')
+:add_alias('save-toolbar')
 :register(function(player)
     local quickbar_names = {}
     for i=1, 100 do
         local slot = player.get_quick_bar_slot(i)
         if slot ~= nil then
-            table.insert(quickbar_names, slot.name)
-        else
-            table.insert(quickbar_names, "")
+            table.insert(quickbar_names, i, slot.name)
         end
     end
-    game.write_file("quickbar_preset.txt", game.table_to_json(quickbar_names), false)
-    Commands.print("Quickbar saved to local script-output folder")
+    game.write_file("quickbar_preset.txt", player.name .. " = " .. serpent.line(quickbar_names) .. "\n", true)
+    Commands.print("Quickbar saved")
 end)

--- a/modules/commands/quickbar.lua
+++ b/modules/commands/quickbar.lua
@@ -1,7 +1,6 @@
 --[[-- Commands Module - Quickbar
     - Adds a command that allows players to load Quickbar presets
-    @commands LoadQuickbar
-    @commands SaveQuickbar
+    @commands Quickbar
 ]]
 
 local Commands = require 'expcore.commands' --- @dep expcore.commands


### PR DESCRIPTION
Added a /load-quickbar command:

This reads a pre-set list from config/preset_player_quickbar.lua. {1..100} where 1-10 is quickbar 1, 11-20 is quickbar 2, etc. These use the factorio item names.

Added command file to the loader.
Added command to the sponsor role.
