### PR TITLE
Roles over RCON, clear join message, quickbar fix

### DIFF
--- a/config/expcore/roles.lua
+++ b/config/expcore/roles.lua
@@ -155,7 +155,8 @@ Roles.new_role('Supporter','Sup')
 :allow{
     'command/jail',
     'command/unjail',
-    'command/join-message'
+    'command/join-message',
+    'command/join-message-clear'
 }
 
 Roles.new_role('Partner','Part')

--- a/locale/en/commands.cfg
+++ b/locale/en/commands.cfg
@@ -1,3 +1,7 @@
+[expcom-general]
+no-player-origin=No originating player
+no-player-target=No player target
+
 [expcom-kill]
 already-dead=You are already dead.
 

--- a/locale/en/data.cfg
+++ b/locale/en/data.cfg
@@ -1,6 +1,7 @@
 [join-message]
 greet=[color=0,1,0] Welcome to explosive gaming community server! If you like the server join our discord: __1__ [/color]
 message-set=Your join message has been updated.
+message-deleted=Your join message has been deleted
 
 [quickbar]
 saved=Your quickbar filters have been saved.

--- a/modules/commands/debug.lua
+++ b/modules/commands/debug.lua
@@ -10,5 +10,6 @@ local Commands = require 'expcore.commands' --- @dep expcore.commands
 -- @command debug
 Commands.new_command('debug', 'Opens the debug pannel for viewing tables.')
 :register(function(player)
+    if not player then return {'expcom-general.no-player-origin'} end
     DebugView.open_dubug(player)
 end)

--- a/modules/commands/find.lua
+++ b/modules/commands/find.lua
@@ -13,6 +13,7 @@ Commands.new_command('find-on-map', 'Find a player on your map.')
 :add_param('player', false, 'player-online')
 :add_alias('find', 'zoom-to')
 :register(function(player, action_player)
+    if not player then return {'expcom-general.no-player-origin'} end
     local position = action_player.position
     player.zoom_to_world(position, 1.75)
     return Commands.success -- prevents command complete message from showing

--- a/modules/commands/me.lua
+++ b/modules/commands/me.lua
@@ -4,6 +4,7 @@
 ]]
 
 local Commands = require 'expcore.commands' --- @dep expcore.commands
+local Colours = require 'utils.color_presets' --- @dep utils.color_presets
 
 --- Sends an action message in the chat
 -- @command me
@@ -12,6 +13,7 @@ Commands.new_command('me', 'Sends an action message in the chat')
 :add_param('action', false)
 :enable_auto_concat()
 :register(function(player, action)
-    local player_name = player and player.name or '<Server>'
-    game.print(string.format('* %s %s *', player_name, action), player.chat_color)
+    local player_name = (player and player.name) or '<Server>'
+    local chat_color = (player and player.chat_color) or Colours['turquoise']
+    game.print(string.format('* %s %s *', player_name, action), chat_color)
 end)

--- a/modules/commands/ratio.lua
+++ b/modules/commands/ratio.lua
@@ -20,6 +20,7 @@ end
 Commands.new_command('ratio', 'This command will give the input and output ratios of the selected machine. Use the parameter for calculating the machines needed for that amount of items per second.')
       :add_param('itemsPerSecond', true, 'number')
       :register(function(player, itemsPerSecond)
+            if not player return Commands.error{'expcom-general.no-player-origin'}
             local machine = player.selected -- selected machine
             if not machine then --nil check
                   return Commands.error{'expcom-ratio.notSelecting'}

--- a/modules/commands/roles.lua
+++ b/modules/commands/roles.lua
@@ -19,8 +19,9 @@ Commands.new_command('assign-role', 'Assigns a role to a player')
 :add_alias('rpromote', 'assign', 'role', 'add-role')
 :register(function(player, action_player, role)
     local player_highest = Roles.get_player_highest_role(player)
+    local player_name = player and player.name or '<server>'
     if player_highest.index < role.index then
-        Roles.assign_player(action_player, role, player.name)
+        Roles.assign_player(action_player, role, player_name)
     else
         return Commands.error{'expcom-roles.higher-role'}
     end
@@ -37,8 +38,9 @@ Commands.new_command('unassign-role', 'Unassigns a role from a player')
 :add_alias('rdemote', 'unassign', 'rerole', 'remove-role')
 :register(function(player, action_player, role)
     local player_highest = Roles.get_player_highest_role(player)
+    local player_name = player and player.name or '<server>'
     if player_highest.index < role.index then
-        Roles.unassign_player(action_player, role, player.name)
+        Roles.unassign_player(action_player, role, player_name)
     else
         return Commands.error{'expcom-roles.higher-role'}
     end

--- a/modules/commands/spawn.lua
+++ b/modules/commands/spawn.lua
@@ -23,13 +23,15 @@ Commands.new_command('go-to-spawn', 'Teleport to spawn')
 :add_param('player', true, 'player-role-alive')
 :set_defaults{
     player=function(player)
-        if player.connected and player.character and player.character.health > 0 then
+        if player and player.connected and player.character and player.character.health > 0 then
             return player
         end
     end
 }
 :add_alias('spawn', 'tp-spawn')
 :register(function(player, action_player)
+    if not player then return Commands.error{'expcom-spawn.unavailable'} end
+    if not player.name and not action_player.name then return Commands.error{'expcom-spawn.unavailable'} end
     if not action_player then
         return Commands.error{'expcom-spawn.unavailable'}
     elseif action_player == player then

--- a/modules/commands/teleport.lua
+++ b/modules/commands/teleport.lua
@@ -42,6 +42,7 @@ Commands.new_command('bring', 'Teleports a player to you.')
 :add_param('player', false, 'player-alive')
 :set_flag('admin_only')
 :register(function(player, from_player)
+    if not player then return Commands.error{'expcom-tp.no-position-found'} end
     if from_player.index == player.index then
         -- return if attempting to teleport to self
         return Commands.error{'expcom-tp.to-self'}
@@ -60,6 +61,7 @@ Commands.new_command('goto', 'Teleports you to a player.')
 :add_alias('tp-me', 'tpme')
 :set_flag('admin_only')
 :register(function(player, to_player)
+    if not player then return Commands.error{'expcom-tp.no-position-found'} end
     if to_player.index == player.index then
         -- return if attempting to teleport to self
         return Commands.error{'expcom-tp.to-self'}

--- a/modules/data/bonus.lua
+++ b/modules/data/bonus.lua
@@ -24,6 +24,7 @@ PlayerBonus:set_metadata{
 --- Apply a bonus amount to a player
 local function apply_bonus(player, amount)
     if not amount then return end
+    if not player.name then return end
     for bonus, min_max in pairs(config) do
         local increase = min_max[2]*amount
         player[bonus] = min_max[1]+increase

--- a/modules/data/greetings.lua
+++ b/modules/data/greetings.lua
@@ -34,3 +34,10 @@ Commands.new_command('join-message', 'Sets your custom join message')
     CustomMessages:set(player, message)
     return {'join-message.message-set'}
 end)
+
+Commands.new_command('join-message-clear', 'Clear your join message')
+:register(function(player, message)
+    if not player then return end
+    CustomMessages:remove(player)
+    return {'join-message.message-deleted'}
+end)

--- a/modules/data/quickbar.lua
+++ b/modules/data/quickbar.lua
@@ -37,10 +37,27 @@ Commands.new_command('save-quickbar', 'Saves your Quickbar preset items to file'
 :add_alias('save-toolbar')
 :register(function(player)
     local filters = {}
+    local ignoredItems = {
+        "blueprint",
+        "blueprint-book",
+        "deconstruction-planner",
+        "spidertron-remote",
+        "upgrade-planner"
+    }
+    local function contains(list, x)
+        for _, v in pairs(list) do
+            if v == x then return true end
+        end
+        return false
+    end
+
     for i = 1, 100 do
         local slot = player.get_quick_bar_slot(i)
         if slot ~= nil then
-            filters[i] = slot.name
+            local ignored = contains(ignoredItems, slot.name)
+            if ignored == false then
+                filters[i] = slot.name
+            end
         end
     end
 
@@ -52,3 +69,15 @@ Commands.new_command('save-quickbar', 'Saves your Quickbar preset items to file'
 
     return {'quickbar.saved'}
 end)
+
+    local player = game.players[player_name]
+    for i, item_name in pairs(filters) do
+        if (item_name ~= nil and ignoredItems[item_name] ~= true) then
+            local ignored = contains(ignoredItems, item_name)
+            if ignored == false then
+                game.print(item_name)
+                game.print(ignoredItems[item_name])
+                player.set_quick_bar_slot(i, item_name)
+            end
+        end
+    end

--- a/modules/data/quickbar.lua
+++ b/modules/data/quickbar.lua
@@ -69,15 +69,3 @@ Commands.new_command('save-quickbar', 'Saves your Quickbar preset items to file'
 
     return {'quickbar.saved'}
 end)
-
-    local player = game.players[player_name]
-    for i, item_name in pairs(filters) do
-        if (item_name ~= nil and ignoredItems[item_name] ~= true) then
-            local ignored = contains(ignoredItems, item_name)
-            if ignored == false then
-                game.print(item_name)
-                game.print(ignoredItems[item_name])
-                player.set_quick_bar_slot(i, item_name)
-            end
-        end
-    end


### PR DESCRIPTION
## Allow roles to be set over RCON
Since a lot of stuff is already done with RCON, why not allow roles to be set this way too, using `/assign` and `/unassign`?
Changes the player name to be either the player's name or `<server>`, as that is the only valid option for what could happen.
## Command to clear join message
New command to clear your join message. 
## Save-quickbar bugfix
The quickbar sync had an issue where items with unique IDs would be just replaced by general items, i.e. a deconstruction planner with a specific filter would be replaced by a generic deconstruction planner. This has been fixed by checking if an item is a list of set items, which include:
- Spidertron remotes (unique ID to spidertron, changes every time spidertron dies, etc)
- Deconstruction planner
- Upgrade planner
- Blueprint book
- Blueprint
If the item is in this list, it is ignored and not pushed to the user's settings of quickbar syncing.