### PR TITLE
Allow players to mark their own buildings & entities for deconstruction

### DIFF
--- a/modules/addons/tree-decon.lua
+++ b/modules/addons/tree-decon.lua
@@ -15,6 +15,7 @@ end)
 
 -- Add trees to queue when marked, only allows simple entities and for players with role permission
 Event.add(defines.events.on_marked_for_deconstruction, function(event)
+    game.print("marked for decon!")
     -- Check which type of decon a player is allowed
     local index = event.player_index
     if not index then return end
@@ -29,6 +30,9 @@ Event.add(defines.events.on_marked_for_deconstruction, function(event)
     local entity = event.entity
     local allow = chache[index]
     if not entity or not entity.valid then return end
+
+    -- allow the entity to be marked for decon if the player built it
+    if last_user.name == game.get_player(event.player_index).name then return end
 
     -- Not allowed to decon this entity
     local last_user = entity.last_user


### PR DESCRIPTION
If a player builds something, why not let them use a deconstruction planner on it, even if they don't have a role?
Basically, a player can construct something and then use the decon planner to deconstruct it, the game won't un-mark it as deconstructed now (if the building/entity is their own).
That's literally all this PR does. I used `game.get_player` as I thought the game could do it more effectively, but I guess `game.players[]` works as well.