### PR TITLE
Fix of player not being valid when killing themselves

### DIFF
--- a/modules/data/statistics.lua
+++ b/modules/data/statistics.lua
@@ -131,7 +131,7 @@ if config.Kills then
         local character = event.cause -- Check character is valid
         if not character or not character.valid or character.type ~= 'character' then return end
         local player = character.player -- Check player is valid
-        if not player.valid or not player.connected then return end
+        if not player or not player.valid or not player.connected then return end
         local entity = event.entity -- Check entity is valid
         if not entity.valid or entity.force == player.force or entity.force.name == 'neutral' then return end
         stat:increment(player)


### PR DESCRIPTION
When a player killed themselves with PvP enabled, the game couldn't access the player. This fixes it.