### PR TITLE
Auto jail for reports and other fixes

### DIFF
--- a/config/_file_loader.lua
+++ b/config/_file_loader.lua
@@ -43,6 +43,7 @@ return {
     'modules.addons.discord-alerts',
     'modules.addons.chat-reply',
     'modules.addons.tree-decon',
+    'modules.addons.report-jail',
 
     --- Data
     'modules.data.statistics',

--- a/config/gui/player_list_actions.lua
+++ b/config/gui/player_list_actions.lua
@@ -173,6 +173,7 @@ return {
         },
         ['command/report'] = {
             auth=function(player,selected_player)
+                if player == selected_player then return false end
                 if not Roles.player_allowed(player,'command/give-warning') then
                     return not Roles.player_has_flag(selected_player,'report-immune')
                 end

--- a/locale/en/addons.cfg
+++ b/locale/en/addons.cfg
@@ -76,3 +76,6 @@ get-mead-2= Skål!
 get-beer-1= 🍺 Pouring A Glass 🍺
 get-beer-2= 🍻 Chears Mate 🍻
 verify=Please return to our discord and type r!verify __1__
+
+[report-jail]
+jail=__1__ was jailed because they have been reported too many times.

--- a/locale/en/addons.cfg
+++ b/locale/en/addons.cfg
@@ -78,4 +78,4 @@ get-beer-2= 🍻 Chears Mate 🍻
 verify=Please return to our discord and type r!verify __1__
 
 [report-jail]
-jail=__1__ was jailed because they have been reported too many times.
+jail=__1__ was jailed because they were reported too many times.

--- a/locale/en/commands.cfg
+++ b/locale/en/commands.cfg
@@ -29,6 +29,7 @@ not-jailed=__1__ is not currently in jail.
 
 [expcom-report]
 player-immune=This player can not be reported.
+self-report=You can not report your self.
 non-admin=__1__ was reported for __2__.
 admin=__1__ was reported by __2__ for __3__.
 already-reported=You can only report a player once, you can ask a moderator to clear this report.

--- a/locale/en/commands.cfg
+++ b/locale/en/commands.cfg
@@ -29,7 +29,7 @@ not-jailed=__1__ is not currently in jail.
 
 [expcom-report]
 player-immune=This player can not be reported.
-self-report=You can not report your self.
+self-report=You cannot report yourself.
 non-admin=__1__ was reported for __2__.
 admin=__1__ was reported by __2__ for __3__.
 already-reported=You can only report a player once, you can ask a moderator to clear this report.

--- a/modules/addons/report-jail.lua
+++ b/modules/addons/report-jail.lua
@@ -1,4 +1,4 @@
---- When a player is reported by players with a greater combined delta playtime, the player is automatically jailed
+--- When a player is reported, the player is automatically jailed if the combined playtime of the reporters exceeds the reported player
 -- @addon report-jail
 
 local Event = require 'utils.event' ---@dep utils.event
@@ -6,7 +6,7 @@ local Jail = require 'modules.control.jail' ---@dep modules.control.jail
 local Reports = require 'modules.control.reports' --- @dep modules.control.reports
 local format_chat_player_name = _C.format_chat_player_name --- @dep expcore.common
 
---- Returns the playtime of the reporter, used to sum the playtime of all reporters
+--- Returns the playtime of the reporter. Used when calculating the total playtime of all reporters
 local function reporter_playtime(_, by_player_name, _)
     local player = game.get_player(by_player_name)
     if player == nil then return 0 end

--- a/modules/addons/report-jail.lua
+++ b/modules/addons/report-jail.lua
@@ -1,0 +1,25 @@
+--- When a player is reported by players with a greater combined delta playtime, the player is automatically jailed
+-- @addon report-jail
+
+local Event = require 'utils.event' ---@dep utils.event
+local Jail = require 'modules.control.jail' ---@dep modules.control.jail
+local Reports = require 'modules.control.reports' --- @dep modules.control.reports
+local format_chat_player_name = _C.format_chat_player_name --- @dep expcore.common
+
+--- Returns the playtime of the reporter, used to sum the playtime of all reporters
+local function reporter_playtime(_, by_player_name, _)
+    local player = game.get_player(by_player_name)
+    if player == nil then return 0 end
+    return player.online_time
+end
+
+--- Tests the combined playtime of all reporters against the reported player
+Event.add(Reports.events.on_player_reported, function(event)
+    local player = game.get_player(event.player_index)
+    local total_playtime = Reports.count_reports(player, reporter_playtime)
+    if total_playtime < player.online_time*1.5 then return end
+    -- Combined playtime is greater than 150% of the reported's playtime
+    local player_name_color = format_chat_player_name(player)
+    Jail.jail_player(player, '<reports>', 'Reported by too many players, please wait for a moderator.')
+    game.print{'report-jail.jail', player_name_color}
+end)

--- a/modules/commands/reports.lua
+++ b/modules/commands/reports.lua
@@ -9,6 +9,15 @@ local Reports = require 'modules.control.reports' --- @dep modules.control.repor
 local format_chat_player_name = _C.format_chat_player_name--- @dep expcore.common
 require 'config.expcore.command_general_parse'
 
+--- Print a message to all players who match the value of admin
+local function print_to_players(admin, message)
+    for _, player in ipairs(game.connected_players) do
+        if player.admin == admin then
+            player.print(message)
+        end
+    end
+end
+
 --- Reports a player and notifies moderators
 -- @command report
 -- @tparam LuaPlayer player the player to report, some players are immune
@@ -30,8 +39,8 @@ end)
     local action_player_name_color = format_chat_player_name(action_player)
     local by_player_name_color = format_chat_player_name(player)
     if Reports.report_player(action_player, player.name, reason) then
-        game.print{'expcom-report.non-admin', action_player_name_color, reason}
-        Roles.print_to_roles_higher('Trainee', {'expcom-report.admin', action_player_name_color, by_player_name_color, reason})
+        print_to_players(false, {'expcom-report.non-admin', action_player_name_color, reason})
+        print_to_players(true,  {'expcom-report.admin', action_player_name_color, by_player_name_color, reason})
     else
         return Commands.error{'expcom-report.already-reported'}
     end

--- a/modules/commands/reports.lua
+++ b/modules/commands/reports.lua
@@ -28,6 +28,8 @@ Commands.new_command('report', 'Reports a player and notifies moderators')
     if not input then return end
     if Roles.player_has_flag(input, 'report-immune') then
         return reject{'expcom-report.player-immune'}
+    elseif player == input then
+        return reject{'expcom-report.self-report'}
     else
         return input
     end

--- a/modules/control/reports.lua
+++ b/modules/control/reports.lua
@@ -132,7 +132,7 @@ function Reports.report_player(player, by_player_name, reason)
     if not player then return end
     local player_name = player.name
 
-    reason = reason or 'Non given.'
+    if reason == nil or not reason:find("/S") then reason = 'Non given' end
 
     local reports = user_reports[player_name]
     if not reports then

--- a/modules/control/reports.lua
+++ b/modules/control/reports.lua
@@ -132,7 +132,7 @@ function Reports.report_player(player, by_player_name, reason)
     if not player then return end
     local player_name = player.name
 
-    if reason == nil or not reason:find("/S") then reason = 'Non given' end
+    if reason == nil or not reason:find("/S") then reason = 'No reason given' end
 
     local reports = user_reports[player_name]
     if not reports then

--- a/modules/gui/player-list.lua
+++ b/modules/gui/player-list.lua
@@ -72,9 +72,10 @@ Gui.element{
 }
 :style(Gui.sprite_style(30, -1, { left_margin = -2, right_margin = -1 }))
 :on_click(function(player, element)
-    local reason = element.parent.entry.text or 'Non Given'
+    local reason = element.parent.entry.text
     local action_name = SelectedAction:get(player)
     local reason_callback = config.buttons[action_name].reason_callback
+    if reason == nil or not reason:find("/S") then reason = 'no reason given' end
     reason_callback(player, reason)
     SelectedPlayer:remove(player)
     SelectedAction:remove(player)


### PR DESCRIPTION
Reports will automatically jail a player after the combined player time of reporters exceeds 150% of the reported player's playtime. Also fixes empty reason strings, double output for admins and self reporting.