### PR TITLE
Added a button to toggle fast decon mode

### DIFF
--- a/locale/en/gui.cfg
+++ b/locale/en/gui.cfg
@@ -170,3 +170,6 @@ data-statistics=Statistics
 data-required=Required
 data-misc=Miscellaneous
 data-format=__1____2__
+
+[tree-decon]
+main-tooltip=Toggle fast tree decon

--- a/locale/en/gui.cfg
+++ b/locale/en/gui.cfg
@@ -175,4 +175,4 @@ data-format=__1____2__
 main-tooltip=Toggle fast tree decon
 enabled=enabled
 disabled=disabled
-toggle-msg=Fast decon has been
+toggle-msg=Fast decon has been __1__

--- a/locale/en/gui.cfg
+++ b/locale/en/gui.cfg
@@ -173,3 +173,6 @@ data-format=__1____2__
 
 [tree-decon]
 main-tooltip=Toggle fast tree decon
+enabled=enabled
+disabled=disabled
+toggle-msg=Fast decon has been

--- a/modules/addons/tree-decon.lua
+++ b/modules/addons/tree-decon.lua
@@ -4,6 +4,7 @@
 local Event = require 'utils.event' --- @dep utils.event
 local Global = require 'utils.global' --- @dep utils.global
 local Roles = require 'expcore.roles' --- @dep expcore.roles
+local PlayerData = require 'expcore.player_data' --- @dep expcore.player_data
 
 -- Global queue used to store trees that need to be removed, also chache for player roles
 local chache = {}
@@ -12,6 +13,22 @@ Global.register({ tree_queue, chache }, function(tbl)
     tree_queue = tbl[1]
     chache = tbl[2]
 end)
+
+
+-- Left menu button to toggle between fast decon and normal decon marking
+local HasEnabledDecon = PlayerData.Settings:combine('HasEnabledDecon')
+HasEnabledDecon:set_default(false)
+
+Gui.toolbar_button("entity/tree-01", {'tree-decon.main-tooltip'}, function (player)
+	return Roles.player_allowed(player, "fast-tree-decon")
+end)
+:on_click(function(player, element)
+	local status = HasEnabledDecon:get(player)
+	HasEnabledDecon:set(player, not status)
+	Gui.toolbar_button_style(element, not status)
+	player.print("Fast decon has been " .. (status and "disabled" or "enabled"))
+end)
+
 
 -- Add trees to queue when marked, only allows simple entities and for players with role permission
 Event.add(defines.events.on_marked_for_deconstruction, function(event)

--- a/modules/addons/tree-decon.lua
+++ b/modules/addons/tree-decon.lua
@@ -27,7 +27,7 @@ end)
 	local status = HasEnabledDecon:get(player)
 	HasEnabledDecon:set(player, not status)
 	Gui.toolbar_button_style(element, not status)
-	player.print("Fast decon has been " .. (status and "disabled" or "enabled"))
+	player.print({'tree-decon.toggle-msg'} .. " " .. (status and {'tree-decon.disabled'} or {'tree-decon.enabled'}))
 end)
 
 

--- a/modules/addons/tree-decon.lua
+++ b/modules/addons/tree-decon.lua
@@ -27,7 +27,7 @@ end)
 	local status = HasEnabledDecon:get(player)
 	HasEnabledDecon:set(player, not status)
 	Gui.toolbar_button_style(element, not status)
-	player.print({'tree-decon.toggle-msg'} .. " " .. (status and {'tree-decon.disabled'} or {'tree-decon.enabled'}))
+	player.print(status and {'tree-decon.toggle-msg', {'tree-decon.disabled'}} or {'tree-decon.toggle-msg', {'tree-decon.enabled'}})
 end)
 
 

--- a/modules/addons/tree-decon.lua
+++ b/modules/addons/tree-decon.lua
@@ -4,6 +4,7 @@
 local Event = require 'utils.event' --- @dep utils.event
 local Global = require 'utils.global' --- @dep utils.global
 local Roles = require 'expcore.roles' --- @dep expcore.roles
+local Gui = require 'expcore.gui' --- @dep expcore.gui
 local PlayerData = require 'expcore.player_data' --- @dep expcore.player_data
 
 -- Global queue used to store trees that need to be removed, also chache for player roles


### PR DESCRIPTION
Added a button in the top left bar to toggle between fast decon mode and normal decon mode. Requires #217 to be merged to function properly and show the button to only those who have the `fast-tree-decon` permission.