### PR TITLE
Disable protection after a player played for long enough

### DIFF
--- a/config/protection.lua
+++ b/config/protection.lua
@@ -3,6 +3,7 @@ return {
     ignore_permission = 'bypass-entity-protection', --- @setting ignore_permission Players with this permission will be ignored by the protection filter, leave nil if expcore.roles is not used
     repeat_count = 5, --- @setting repeat_count Number of protected entities that must be removed within repeat_lifetime in order to trigger repeated removal protection
     repeat_lifetime = 3600*20, --- @setting repeat_lifetime The length of time, in ticks, that protected removals will be remembered for
+    repeat_endtime = 3600*30, --- @setting repeat_endtime The length of time, in ticks, that entity protection will stop applying for players (with their playtime) and they will not be jailed for protected entities. 0 for disabled
     refresh_rate = 3600*5, --- @setting refresh_rate How often the age of protected removals are checked against repeat_lifetime
     always_protected_names = { --- @setting always_protected_names Names of entities which are always protected
 

--- a/modules/control/protection.lua
+++ b/modules/control/protection.lua
@@ -160,6 +160,9 @@ Event.add(defines.events.on_pre_player_mined_item, function(event)
     if entity.last_user == nil or entity.last_user.index == player.index then return end
     if config.ignore_permission and Roles.player_allowed(player, config.ignore_permission) then return end
 
+    -- Check if player played long enough to be ignored
+    if config.repeat_endtime ~= 0 and config.repeat_endtime < player.online_time then return end
+
     -- Check if the entity is protected
     if EntityProtection.is_entity_protected(entity)
     or EntityProtection.is_position_protected(entity.surface, entity.position)


### PR DESCRIPTION
This PR adds a feature to disable protection and protected entities if a player has played long enough. Default is 30 minutes.