### PR TITLE
Fix transfer of items after death and ban

### DIFF
--- a/expcore/common.lua
+++ b/expcore/common.lua
@@ -645,10 +645,12 @@ function Common.move_items_stack(items, surface, position, radius, chest_type)
 	local last_chest
 	for i=1,#items do
 			local item = items[i]
-			local chest = next_chest(item)
-			if not chest or not chest.valid then return error(string.format('Cant move item %s to %s{%s, %s} no valid chest in radius', item_name, surface.name, p.x, p.y)) end
-			chest.insert(item)
-			last_chest = chest
+			if item.valid_for_read then
+				local chest = next_chest(item)
+				if not chest or not chest.valid then return error(string.format('Cant move item %s to %s{%s, %s} no valid chest in radius', item_name, surface.name, p.x, p.y)) end
+				chest.insert(item)
+				last_chest = chest
+			end
 	end
 	return last_chest
 end

--- a/expcore/common.lua
+++ b/expcore/common.lua
@@ -539,6 +539,7 @@ end
 -- @section factorio
 
 --[[-- Moves items to the position and stores them in the closest entity of the type given
+-- Copies the items by prototype name, but keeps them in the original inventory
 @tparam table items items which are to be added to the chests, ['name']=count
 @tparam[opt=navies] LuaSurface surface the surface that the items will be moved to
 @tparam[opt={0, 0}] table position the position that the items will be moved to {x=100, y=100}
@@ -596,6 +597,7 @@ function Common.move_items(items, surface, position, radius, chest_type)
 end
 
 --[[-- Moves items to the position and stores them in the closest entity of the type given
+-- Differs from move_items by accepting a table of LuaItemStack and transferring them into the inventory - not copying
 @tparam table items items which are to be added to the chests, an array of LuaItemStack
 @tparam[opt=navies] LuaSurface surface the surface that the items will be moved to
 @tparam[opt={0, 0}] table position the position that the items will be moved to {x=100, y=100}
@@ -647,7 +649,7 @@ function Common.move_items_stack(items, surface, position, radius, chest_type)
 			local item = items[i]
 			if item.valid_for_read then
 				local chest = next_chest(item)
-				if not chest or not chest.valid then return error(string.format('Cant move item %s to %s{%s, %s} no valid chest in radius', item_name, surface.name, p.x, p.y)) end
+				if not chest or not chest.valid then return error(string.format('Cant move item %s to %s{%s, %s} no valid chest in radius', item.name, surface.name, p.x, p.y)) end
 				chest.insert(item)
 				last_chest = chest
 			end

--- a/modules/addons/death-logger.lua
+++ b/modules/addons/death-logger.lua
@@ -4,7 +4,7 @@
 local Event = require 'utils.event' --- @dep utils.event
 local Global = require 'utils.global' --- @dep utils.global
 local config = require 'config.death_logger' --- @dep config.death_logger
-local format_time, move_items = _C.format_time, _C.move_items --- @dep expcore.common
+local format_time, move_items = _C.format_time, _C.move_items_stack --- @dep expcore.common
 
 -- Max amount of ticks a corpse can be alive
 local corpse_lifetime = 60*60*15
@@ -64,7 +64,7 @@ Event.add(defines.events.on_player_died, function(event)
     local player = game.players[event.player_index]
     local corpse = player.surface.find_entity('character-corpse', player.position)
     if config.use_chests_as_bodies then
-        local items = corpse.get_inventory(defines.inventory.character_corpse).get_contents()
+        local items = corpse.get_inventory(defines.inventory.character_corpse)
         local chest = move_items(items, corpse.surface, corpse.position)
         chest.destructible = false
         corpse.destroy()
@@ -140,7 +140,7 @@ end
 if config.auto_collect_bodies then
     Event.add(defines.events.on_character_corpse_expired, function(event)
         local corpse = event.corpse
-        local items = corpse.get_inventory(defines.inventory.character_corpse).get_contents()
+        local items = corpse.get_inventory(defines.inventory.character_corpse)
         move_items(items, corpse.surface, {x=0, y=0})
     end)
 end

--- a/modules/addons/inventory-clear.lua
+++ b/modules/addons/inventory-clear.lua
@@ -3,12 +3,12 @@
 
 local Event = require 'utils.event' --- @dep utils.event
 local events = require 'config.inventory_clear' --- @dep config.inventory_clear
-local move_items = _C.move_items --- @dep expcore.common
+local move_items_stack = _C.move_items_stack --- @dep expcore.common
 
 local function clear_items(event)
     local player = game.players[event.player_index]
     local inv = player.get_main_inventory()
-    move_items(inv.get_contents())
+    move_items_stack(inv)
     inv.clear()
 end
 

--- a/modules/commands/clear-inventory.lua
+++ b/modules/commands/clear-inventory.lua
@@ -4,7 +4,7 @@
 ]]
 
 local Commands = require 'expcore.commands' --- @dep expcore.commands
-local move_items = _C.move_items --- @dep expcore.common
+local move_items_stack = _C.move_items_stack --- @dep expcore.common
 require 'config.expcore.command_role_parse'
 
 --- Clears a players inventory
@@ -14,10 +14,10 @@ Commands.new_command('clear-inventory', 'Clears a players inventory')
 :add_param('player', false, 'player-role')
 :add_alias('clear-inv', 'move-inventory', 'move-inv')
 :register(function(_, player)
-    local inv = player.get_main_inventory()
-    if not inv then
-        return Commands.error{'expcore-commands.reject-player-alive'}
-    end
-    move_items(inv.get_contents())
-    inv.clear()
+  local inv = player.get_main_inventory()
+  if not inv then
+    return Commands.error{'expcore-commands.reject-player-alive'}
+  end
+  move_items_stack(inv)
+  inv.clear()
 end)


### PR DESCRIPTION
Fixed an issue where items would be transferred only by name and "copied", which would cause issues with items with metadata, for example contents of power armor.