### PR TITLE
Implement nuke protect, fix move_items

### DIFF
--- a/config/_file_loader.lua
+++ b/config/_file_loader.lua
@@ -51,6 +51,7 @@ return {
     'modules.addons.report-jail',
     'modules.addons.protection-jail',
 		'modules.addons.deconlog',
+		'modules.addons.nukeprotect',
 
     --- Data
     'modules.data.statistics',

--- a/config/expcore/roles.lua
+++ b/config/expcore/roles.lua
@@ -223,7 +223,8 @@ Roles.new_role('Regular','Reg')
     'command/go-to-spawn',
     'command/me',
     'standard-decon',
-    'bypass-entity-protection'
+    'bypass-entity-protection',
+		'bypass-nukeprotect'
 }
 :set_auto_assign_condition(function(player)
     if player.online_time >= hours3 then

--- a/config/expcore/roles.lua
+++ b/config/expcore/roles.lua
@@ -291,7 +291,7 @@ Roles.define_role_order{
 }
 
 Roles.override_player_roles{
-    ["oof2win2"]={"Senior Administrator","Moderator","Senior Backer","Supporter"},
+    ["Cooldude2606"]={"Senior Administrator","Moderator","Senior Backer","Supporter"},
     ["arty714"]={"Senior Administrator","Senior Backer","Supporter"},
     ["Drahc_pro"]={"Administrator","Moderator","Veteran","Member"},
     ["mark9064"]={"Administrator","Moderator","Member"},

--- a/config/expcore/roles.lua
+++ b/config/expcore/roles.lua
@@ -291,7 +291,7 @@ Roles.define_role_order{
 }
 
 Roles.override_player_roles{
-    ["Cooldude2606"]={"Senior Administrator","Moderator","Senior Backer","Supporter"},
+    ["oof2win2"]={"Senior Administrator","Moderator","Senior Backer","Supporter"},
     ["arty714"]={"Senior Administrator","Senior Backer","Supporter"},
     ["Drahc_pro"]={"Administrator","Moderator","Veteran","Member"},
     ["mark9064"]={"Administrator","Moderator","Member"},

--- a/config/nukeprotect.lua
+++ b/config/nukeprotect.lua
@@ -1,12 +1,30 @@
 return {
-	[tostring(defines.inventory.character_ammo)] = {
-		["atomic-bomb"] = true
-	}, -- @setting ammo The items to not allow in the player's ammo inventory
-	[tostring(defines.inventory.character_armor)] = {}, -- @setting armor The items to not allow in the player's armor inventory
-	[tostring(defines.inventory.character_guns)] = {}, -- @setting gun The items to not allow in the player's gun inventory
-	[tostring(defines.inventory.character_main)] = {
-		["atomic-bomb"] = true
-	}, -- @setting main The items to not allow in the player's main inventory
+	inventories = {
+		{
+			inventory = defines.inventory.character_ammo,
+			event = defines.events.on_player_ammo_inventory_changed,
+			items = {
+				["atomic-bomb"] = true
+			},
+		},
+		{
+			inventory = defines.inventory.character_armor,
+			event = defines.events.on_player_armor_inventory_changed,
+			items = {},
+		},
+		{
+			inventory = defines.inventory.character_guns,
+			event = defines.events.on_player_gun_inventory_changed,
+			items = {},
+		},
+		{
+			inventory = defines.inventory.character_main,
+			event = defines.events.on_player_main_inventory_changed,
+			items = {
+				["atomic-bomb"] = true
+			},
+		},
+	},
 	ignore_permisison = "bypass-nukeprotect", -- @setting ignore_permisison The permission that nukeprotect will ignore
 	ignore_admins = true, -- @setting ignore_admins Ignore admins, true by default. Allows usage outside of the roles module
 }

--- a/config/nukeprotect.lua
+++ b/config/nukeprotect.lua
@@ -1,0 +1,11 @@
+return {
+	ammo = {
+		["atomic-bomb"] = true
+	}, -- @setting ammo The items to not allow in the player's ammo inventory
+	armor = {}, -- @setting armor The items to not allow in the player's armor inventory
+	gun = {}, -- @setting gun The items to not allow in the player's gun inventory
+	main = {
+		["atomic-bomb"] = true
+	}, -- @setting main The items to not allow in the player's main inventory
+	ignore_permisison = "bypass-nukeprotect" -- @setting ignore_permisison The permission that nukeprotect will ignore
+}

--- a/config/nukeprotect.lua
+++ b/config/nukeprotect.lua
@@ -1,11 +1,12 @@
 return {
-	ammo = {
+	[tostring(defines.inventory.character_ammo)] = {
 		["atomic-bomb"] = true
 	}, -- @setting ammo The items to not allow in the player's ammo inventory
-	armor = {}, -- @setting armor The items to not allow in the player's armor inventory
-	gun = {}, -- @setting gun The items to not allow in the player's gun inventory
-	main = {
+	[tostring(defines.inventory.character_armor)] = {}, -- @setting armor The items to not allow in the player's armor inventory
+	[tostring(defines.inventory.character_guns)] = {}, -- @setting gun The items to not allow in the player's gun inventory
+	[tostring(defines.inventory.character_main)] = {
 		["atomic-bomb"] = true
 	}, -- @setting main The items to not allow in the player's main inventory
-	ignore_permisison = "bypass-nukeprotect" -- @setting ignore_permisison The permission that nukeprotect will ignore
+	ignore_permisison = "bypass-nukeprotect", -- @setting ignore_permisison The permission that nukeprotect will ignore
+	ignore_admins = true, -- @setting ignore_admins Ignore admins, true by default. Allows usage outside of the roles module
 }

--- a/expcore/common.lua
+++ b/expcore/common.lua
@@ -540,7 +540,7 @@ end
 
 --[[-- Moves items to the position and stores them in the closest entity of the type given
 -- Copies the items by prototype name, but keeps them in the original inventory
-@tparam table items items which are to be added to the chests, ['name']=count
+@tparam table items items which are to be added to the chests, an array of LuaItemStack
 @tparam[opt=navies] LuaSurface surface the surface that the items will be moved to
 @tparam[opt={0, 0}] table position the position that the items will be moved to {x=100, y=100}
 @tparam[opt=32] number radius the radius in which the items are allowed to be placed
@@ -551,49 +551,52 @@ end
 move_items(game.player.get_main_inventory().get_contents())
 
 ]]
-function Common.move_items(items, surface, position, radius, chest_type)
-    chest_type = chest_type or 'iron-chest'
-    surface = surface or game.surfaces[1]
-    if position and type(position) ~= 'table' then return end
-    if type(items) ~= 'table' then return end
-    -- Finds all entities of the given type
-    local p = position or {x=0, y=0}
-    local r = radius or 32
-    local entities = surface.find_entities_filtered{area={{p.x-r, p.y-r}, {p.x+r, p.y+r}}, name=chest_type} or {}
-    local count = #entities
-    local current = 1
-    -- Makes a new empty chest when it is needed
-    local function make_new_chest()
-        local pos = surface.find_non_colliding_position(chest_type, position, 32, 1)
-        local chest = surface.create_entity{name=chest_type, position=pos, force='neutral'}
-        table.insert(entities, chest)
-        count = count + 1
-        return chest
-    end
-    -- Function used to round robin the items into all chests
-    local function next_chest(item)
-        local chest = entities[current]
-        if count == 0 then return make_new_chest() end
-        if chest.get_inventory(defines.inventory.chest).can_insert(item) then
-            -- If the item can be inserted then the chest is returned
-            current = current+1
-            if current > count then current = 1 end
-            return chest
-        else
-            -- Other wise it is removed from the list
-            table.remove(entities, current)
-            count = count - 1
-        end
-    end
-    -- Inserts the items into the chests
-    local last_chest
-    for item_name, item_count in pairs(items) do
-        local chest = next_chest{name=item_name, count=item_count}
-        if not chest then return error(string.format('Cant move item %s to %s{%s, %s} no valid chest in radius', item_name, surface.name, p.x, p.y)) end
-        Util.insert_safe(chest, {[item_name]=item_count})
-        last_chest = chest
-    end
-    return last_chest
+function Common.copy_items_stack(items, surface, position, radius, chest_type)
+	chest_type = chest_type or 'iron-chest'
+	surface = surface or game.surfaces[1]
+	if position and type(position) ~= 'table' then return end
+	if type(items) ~= 'table' then return end
+	-- Finds all entities of the given type
+	local p = position or {x=0, y=0}
+	local r = radius or 32
+	local entities = surface.find_entities_filtered{area={{p.x-r, p.y-r}, {p.x+r, p.y+r}}, name=chest_type} or {}
+	local count = #entities
+	local current = 1
+	-- Makes a new empty chest when it is needed
+	local function make_new_chest()
+			local pos = surface.find_non_colliding_position(chest_type, position, 32, 1)
+			local chest = surface.create_entity{name=chest_type, position=pos, force='neutral'}
+			table.insert(entities, chest)
+			count = count + 1
+			return chest
+	end
+	-- Function used to round robin the items into all chests
+	local function next_chest(item)
+			local chest = entities[current]
+			if count == 0 then return make_new_chest() end
+			if chest.get_inventory(defines.inventory.chest).can_insert(item) then
+					-- If the item can be inserted then the chest is returned
+					current = current+1
+					if current > count then current = 1 end
+					return chest
+			else
+					-- Other wise it is removed from the list
+					table.remove(entities, current)
+					count = count - 1
+			end
+	end
+	-- Inserts the items into the chests
+	local last_chest
+	for i=1,#items do
+			local item = items[i]
+			if item.valid_for_read then
+				local chest = next_chest(item)
+				if not chest or not chest.valid then return error(string.format('Cant move item %s to %s{%s, %s} no valid chest in radius', item.name, surface.name, p.x, p.y)) end
+				chest.insert(item)
+				last_chest = chest
+			end
+	end
+	return last_chest
 end
 
 --[[-- Moves items to the position and stores them in the closest entity of the type given
@@ -650,7 +653,9 @@ function Common.move_items_stack(items, surface, position, radius, chest_type)
 			if item.valid_for_read then
 				local chest = next_chest(item)
 				if not chest or not chest.valid then return error(string.format('Cant move item %s to %s{%s, %s} no valid chest in radius', item.name, surface.name, p.x, p.y)) end
-				chest.insert(item)
+				local empty_stack = chest.get_inventory(defines.inventory.chest).find_empty_stack(item.name)
+				if not empty_stack then return error(string.format('Cant move item %s to %s{%s, %s} no valid chest in radius', item.name, surface.name, p.x, p.y)) end
+				empty_stack.transfer_stack(item)
 				last_chest = chest
 			end
 	end

--- a/expcore/common.lua
+++ b/expcore/common.lua
@@ -6,7 +6,6 @@
 
 local Colours = require 'utils.color_presets' --- @dep utils.color_presets
 local Game = require 'utils.game' --- @dep utils.game
-local Util = require 'util' --- @dep util
 
 local Common = {}
 

--- a/expcore/common.lua
+++ b/expcore/common.lua
@@ -538,17 +538,17 @@ end
 --- Factorio.
 -- @section factorio
 
---[[-- Moves items to the position and stores them in the closest entity of the type given
+--[[-- Copies items to the position and stores them in the closest entity of the type given
 -- Copies the items by prototype name, but keeps them in the original inventory
 @tparam table items items which are to be added to the chests, an array of LuaItemStack
-@tparam[opt=navies] LuaSurface surface the surface that the items will be moved to
-@tparam[opt={0, 0}] table position the position that the items will be moved to {x=100, y=100}
+@tparam[opt=navies] LuaSurface surface the surface that the items will be copied to
+@tparam[opt={0, 0}] table position the position that the items will be copied to {x=100, y=100}
 @tparam[opt=32] number radius the radius in which the items are allowed to be placed
-@tparam[opt=iron-chest] string chest_type the chest type that the items should be moved into
+@tparam[opt=iron-chest] string chest_type the chest type that the items should be copied into
 @treturn LuaEntity the last chest that had items inserted into it
 
 @usage-- Copy all the items in a players inventory and place them in chests at {0, 0}
-move_items(game.player.get_main_inventory().get_contents())
+copy_items_stack(game.player.get_main_inventory().get_contents())
 
 ]]
 function Common.copy_items_stack(items, surface, position, radius, chest_type)
@@ -609,7 +609,7 @@ end
 @treturn LuaEntity the last chest that had items inserted into it
 
 @usage-- Copy all the items in a players inventory and place them in chests at {0, 0}
-move_items(game.player.get_main_inventory())
+move_items_stack(game.player.get_main_inventory())
 
 ]]
 function Common.move_items_stack(items, surface, position, radius, chest_type)

--- a/locale/en/addons.cfg
+++ b/locale/en/addons.cfg
@@ -85,7 +85,4 @@ jail=__1__ was jailed because they were reported too many times. Please wait for
 jail=__1__ was jailed because they removed too many protected entities. Please wait for a moderator.
 
 [nukeprotect]
-ammo=You cannot have __1__ in your ammo inventory, so it was placed into the chests at spawn.
-armor=You cannot have __1__ in your armor inventory, so it was placed into the chests at spawn.
-gun=You cannot have __1__ in your gun inventory, so it was placed into the chests at spawn.
-main=You cannot have __1__ in your main inventory, so it was placed into the chests at spawn.
+found=You cannot have __1__ in your inventory, so it was placed into the chests at spawn.

--- a/locale/en/addons.cfg
+++ b/locale/en/addons.cfg
@@ -83,3 +83,9 @@ jail=__1__ was jailed because they were reported too many times. Please wait for
 
 [protection-jail]
 jail=__1__ was jailed because they removed too many protected entities. Please wait for a moderator.
+
+[nukeprotect]
+ammo=You cannot have __1__ in your ammo inventory, so it was placed into the chests at spawn.
+armor=You cannot have __1__ in your armor inventory, so it was placed into the chests at spawn.
+gun=You cannot have __1__ in your gun inventory, so it was placed into the chests at spawn.
+main=You cannot have __1__ in your main inventory, so it was placed into the chests at spawn.

--- a/modules/addons/nukeprotect.lua
+++ b/modules/addons/nukeprotect.lua
@@ -24,34 +24,13 @@ local function check_items(player, type)
 	end
 end
 
-if table_size(config[tostring(defines.inventory.character_ammo)]) > 0 then
-	Event.add(defines.events.on_player_ammo_inventory_changed, function(event)
-		local player = game.get_player(event.player_index)
-
-		check_items(player, defines.inventory.character_ammo)
-	end)
-end
-
-if table_size(config[tostring(defines.inventory.character_armor)]) > 0 then
-	Event.add(defines.events.on_player_armor_inventory_changed, function(event)
-		local player = game.get_player(event.player_index)
-
-		check_items(player, defines.inventory.character_armor)
-	end)
-end
-
-if table_size(config[tostring(defines.inventory.character_guns)]) > 0 then
-	Event.add(defines.events.on_player_gun_inventory_changed, function(event)
-		local player = game.get_player(event.player_index)
-
-		check_items(player, defines.inventory.character_guns)
-	end)
-end
-
-if table_size(config[tostring(defines.inventory.character_main)]) > 0 then
-	Event.add(defines.events.on_player_main_inventory_changed, function(event)
-		local player = game.get_player(event.player_index)
-
-		check_items(player, defines.inventory.character_main)
-	end)
+for _, inventory in ipairs(config.inventories) do
+	if #inventory.items > 0 then
+		Event.add(inventory.event, function(event)
+			local player = game.get_player(event.player_index)
+			if player and player.valid then
+				check_items(player, inventory.inventory)
+			end
+		end)
+	end
 end

--- a/modules/addons/nukeprotect.lua
+++ b/modules/addons/nukeprotect.lua
@@ -1,0 +1,75 @@
+--- Disable new players from having certain items in their inventory, most commonly nukes
+-- @addon Nukeprotect
+
+local Event = require 'utils.event' --- @dep utils.event
+local Roles = require 'expcore.roles' --- @dep expcore.roles
+local config = require 'config.nukeprotect' --- @dep config.nukeprotect
+local move_items_stack = _C.move_items_stack --- @dep expcore.common
+
+Event.add(defines.events.on_player_ammo_inventory_changed, function(event)
+	local player = game.get_player(event.player_index)
+
+	-- if the player has perms to be ignored, then they should be
+	if config.ignore_permisison and Roles.player_allowed(player, config.ignore_permisison) then return end
+
+	local inv = player.get_inventory(defines.inventory.character_ammo)
+
+	for i = 1, #inv do
+		local item = inv[i]
+		if item.valid and item.valid_for_read and config.ammo[item.name] then
+			player.print({ "nukeprotect.ammo", { "item-name." .. item.name } })
+			move_items_stack({ item })
+		end
+	end
+end)
+
+Event.add(defines.events.on_player_armor_inventory_changed, function(event)
+	local player = game.get_player(event.player_index)
+
+	-- if the player has perms to be ignored, then they should be
+	if config.ignore_permisison and Roles.player_allowed(player, config.ignore_permisison) then return end
+
+	local inv = player.get_inventory(defines.inventory.character_armor)
+
+	for i = 1, #inv do
+		local item = inv[i]
+		if item.valid and item.valid_for_read and config.armor[item.name] then
+			player.print({ "nukeprotect.armor", { "item-name." .. item.name } })
+			move_items_stack({ item })
+		end
+	end
+end)
+
+Event.add(defines.events.on_player_gun_inventory_changed, function(event)
+	local player = game.get_player(event.player_index)
+
+	-- if the player has perms to be ignored, then they should be
+	if config.ignore_permisison and Roles.player_allowed(player, config.ignore_permisison) then return end
+
+	local inv = player.get_inventory(defines.inventory.character_guns)
+
+	for i = 1, #inv do
+		local item = inv[i]
+		if item.valid and item.valid_for_read and config.gun[item.name] then
+			player.print({ "nukeprotect.gun", { "item-name." .. item.name } })
+			move_items_stack({ item })
+		end
+	end
+end)
+
+Event.add(defines.events.on_player_main_inventory_changed, function(event)
+	local player = game.get_player(event.player_index)
+
+	-- if the player has perms to be ignored, then they should be
+	if config.ignore_permisison and Roles.player_allowed(player, config.ignore_permisison) then return end
+
+	local inv = player.get_inventory(defines.inventory.character_main)
+
+	for i = 1, #inv do
+		local item = inv[i]
+		if item.valid and item.valid_for_read and config.main[item.name] then
+			player.print({ "nukeprotect.main", { "item-name." .. item.name } })
+			move_items_stack({ item })
+		end
+	end
+end)

--- a/modules/addons/nukeprotect.lua
+++ b/modules/addons/nukeprotect.lua
@@ -6,70 +6,52 @@ local Roles = require 'expcore.roles' --- @dep expcore.roles
 local config = require 'config.nukeprotect' --- @dep config.nukeprotect
 local move_items_stack = _C.move_items_stack --- @dep expcore.common
 
-Event.add(defines.events.on_player_ammo_inventory_changed, function(event)
-	local player = game.get_player(event.player_index)
 
+local function check_items(player, type)
 	-- if the player has perms to be ignored, then they should be
 	if config.ignore_permisison and Roles.player_allowed(player, config.ignore_permisison) then return end
+	-- if the players
+	if config.ignore_admins and player.admin then return end
 
-	local inv = player.get_inventory(defines.inventory.character_ammo)
-
-	for i = 1, #inv do
-		local item = inv[i]
-		if item.valid and item.valid_for_read and config.ammo[item.name] then
-			player.print({ "nukeprotect.ammo", { "item-name." .. item.name } })
+	local inventory = player.get_inventory(type)
+	for i = 1, #inventory do
+		local item = inventory[i]
+		if item.valid and item.valid_for_read and config[tostring(type)][item.name] then
+			player.print({ "nukeprotect.found", { "item-name." .. item.name } })
+			-- insert the items into the table so all items are transferred at once
 			move_items_stack({ item })
 		end
 	end
-end)
+end
 
-Event.add(defines.events.on_player_armor_inventory_changed, function(event)
-	local player = game.get_player(event.player_index)
+if table_size(config[tostring(defines.inventory.character_ammo)]) > 0 then
+	Event.add(defines.events.on_player_ammo_inventory_changed, function(event)
+		local player = game.get_player(event.player_index)
 
-	-- if the player has perms to be ignored, then they should be
-	if config.ignore_permisison and Roles.player_allowed(player, config.ignore_permisison) then return end
+		check_items(player, defines.inventory.character_ammo)
+	end)
+end
 
-	local inv = player.get_inventory(defines.inventory.character_armor)
+if table_size(config[tostring(defines.inventory.character_armor)]) > 0 then
+	Event.add(defines.events.on_player_armor_inventory_changed, function(event)
+		local player = game.get_player(event.player_index)
 
-	for i = 1, #inv do
-		local item = inv[i]
-		if item.valid and item.valid_for_read and config.armor[item.name] then
-			player.print({ "nukeprotect.armor", { "item-name." .. item.name } })
-			move_items_stack({ item })
-		end
-	end
-end)
+		check_items(player, defines.inventory.character_armor)
+	end)
+end
 
-Event.add(defines.events.on_player_gun_inventory_changed, function(event)
-	local player = game.get_player(event.player_index)
+if table_size(config[tostring(defines.inventory.character_guns)]) > 0 then
+	Event.add(defines.events.on_player_gun_inventory_changed, function(event)
+		local player = game.get_player(event.player_index)
 
-	-- if the player has perms to be ignored, then they should be
-	if config.ignore_permisison and Roles.player_allowed(player, config.ignore_permisison) then return end
+		check_items(player, defines.inventory.character_guns)
+	end)
+end
 
-	local inv = player.get_inventory(defines.inventory.character_guns)
+if table_size(config[tostring(defines.inventory.character_main)]) > 0 then
+	Event.add(defines.events.on_player_main_inventory_changed, function(event)
+		local player = game.get_player(event.player_index)
 
-	for i = 1, #inv do
-		local item = inv[i]
-		if item.valid and item.valid_for_read and config.gun[item.name] then
-			player.print({ "nukeprotect.gun", { "item-name." .. item.name } })
-			move_items_stack({ item })
-		end
-	end
-end)
-
-Event.add(defines.events.on_player_main_inventory_changed, function(event)
-	local player = game.get_player(event.player_index)
-
-	-- if the player has perms to be ignored, then they should be
-	if config.ignore_permisison and Roles.player_allowed(player, config.ignore_permisison) then return end
-
-	local inv = player.get_inventory(defines.inventory.character_main)
-
-	for i = 1, #inv do
-		local item = inv[i]
-		if item.valid and item.valid_for_read and config.main[item.name] then
-			player.print({ "nukeprotect.main", { "item-name." .. item.name } })
-			move_items_stack({ item })
-		end
-	end
-end)
+		check_items(player, defines.inventory.character_main)
+	end)
+end


### PR DESCRIPTION
Changed _C.move_items* to be _C.copy_items_stack, which copies items, and _C.move_items_stack, which moves items.

Added an addon called `nukeprotect`, which prevents players without a flag from having specific items in their inventories.