### PR TITLE
Fixed auto fill amounts not working

### DIFF
--- a/modules/gui/autofill.lua
+++ b/modules/gui/autofill.lua
@@ -177,7 +177,7 @@ end)
     if not value then value = 0 end
     local clamped = math.clamp(value, 0, 1000)
     local item_name = element.parent.tooltip
-    local entity_name = element.parent.parent.parent.parent.name
+    local entity_name = element.parent.parent.parent.name
     if not autofill_player_settings[player.name] then return end
     local setting = autofill_player_settings[player.name][entity_name]
     if not setting then return end


### PR DESCRIPTION
Fixed the issue with auto fill amounts not updating as a result of not finding the entity name.