### PR TITLE
Disable nukes completely

### DIFF
--- a/config/nukeprotect.lua
+++ b/config/nukeprotect.lua
@@ -26,5 +26,9 @@ return {
 		},
 	},
 	ignore_permisison = "bypass-nukeprotect", -- @setting ignore_permisison The permission that nukeprotect will ignore
-	ignore_admins = true, -- @setting ignore_admins Ignore admins, true by default. Allows usage outside of the roles module
+	ignore_admins = true,                  -- @setting ignore_admins Ignore admins, true by default. Allows usage outside of the roles module
+	disable_nuke_research = true,          -- @setting disable_nuke_research Disable the nuke research, true by default
+	disable_nuke_research_names = {
+		["atomic-bomb"] = true
+	} -- @setting disable_nuke_research_names The names of the researches to disabled
 }

--- a/config/nukeprotect.lua
+++ b/config/nukeprotect.lua
@@ -27,7 +27,7 @@ return {
 	},
 	ignore_permisison = "bypass-nukeprotect", -- @setting ignore_permisison The permission that nukeprotect will ignore
 	ignore_admins = true,                  -- @setting ignore_admins Ignore admins, true by default. Allows usage outside of the roles module
-	disable_nuke_research = true,          -- @setting disable_nuke_research Disable the nuke research, true by default
+	disable_nuke_research = false,          -- @setting disable_nuke_research Disable the nuke research, true by default
 	disable_nuke_research_names = {
 		["atomic-bomb"] = true
 	} -- @setting disable_nuke_research_names The names of the researches to disabled

--- a/modules/addons/nukeprotect.lua
+++ b/modules/addons/nukeprotect.lua
@@ -1,9 +1,9 @@
 --- Disable new players from having certain items in their inventory, most commonly nukes
 -- @addon Nukeprotect
 
-local Event = require 'utils.event' --- @dep utils.event
-local Roles = require 'expcore.roles' --- @dep expcore.roles
-local config = require 'config.nukeprotect' --- @dep config.nukeprotect
+local Event = require 'utils.event'          --- @dep utils.event
+local Roles = require 'expcore.roles'        --- @dep expcore.roles
+local config = require 'config.nukeprotect'  --- @dep config.nukeprotect
 local move_items_stack = _C.move_items_stack --- @dep expcore.common
 
 
@@ -33,4 +33,14 @@ for _, inventory in ipairs(config.inventories) do
 			end
 		end)
 	end
+end
+
+
+if config.disable_nuke_research then
+	Event.add(defines.events.on_research_started, function(event)
+		local name = event.research.name
+		if config.disable_nuke_research_names[name] then
+			event.research.force.cancel_current_research()
+		end
+	end)
 end


### PR DESCRIPTION
This PR disables nukes completely by disabling the research for them (configgable), as they don't have much of real use besides griefers using them.