### PR TITLE
Fix #279: Add spectate check to stop_follow

### DIFF
--- a/modules/control/spectate.lua
+++ b/modules/control/spectate.lua
@@ -85,7 +85,9 @@ end
 -- @tparam LuaPlayer player The player that will regain control of their camera
 function Public.stop_follow(player)
     assert(player and player.valid, 'Invalid player given to follower')
-    if following[player.index] and following[player.index][4] then Public.stop_spectate(player) end
+    if following[player.index] and following[player.index][4] and Public.is_spectating(player) then
+        Public.stop_spectate(player)
+    end
 
     Gui.destroy_if_valid(player.gui.screen[follow_label.name])
     following[player.index] = nil


### PR DESCRIPTION
Fixes the issue of spawning a new character when spectate is stopped while follow is active. This was caused by the following logic path:
1) `stop_spectate` would return you to your orginal body.
2) `on_tick` for follow would see you had a character and attempt to stop itself with `stop_follow`
3) Because `start_spectate` was successful in `start_follow` it assumes that `stop_spectate` needs to be called.
4) However, because it has already been called once it now has no reference to your character, this triggers a respawn.
5) Respawning disconnects your orginal body and gives you a new one.